### PR TITLE
Add LINQ tailwind plugins and theme

### DIFF
--- a/tailwind/README.md
+++ b/tailwind/README.md
@@ -38,7 +38,7 @@ Edit your `tailwind.config.js` to use the LINQ design system preset:
 ```js
 module.exports = {
   presets: [
-    require('linq-ds/tailwind').preset,
+    require('linq-ds/tailwind/themes/linq'),
   ],
   content: [
     './src/**/*.{html,ts,js,scss}',
@@ -118,7 +118,7 @@ For bug reports or feature requests, please file an issue.
 // tailwind.config.js
 module.exports = {
   presets: [
-    require('linq-ds/tailwind').preset,
+    require('linq-ds/tailwind/themes/linq'),
   ],
   content: [
     './src/**/*.{html,ts,js,scss}',

--- a/tailwind/config/core.js
+++ b/tailwind/config/core.js
@@ -1,0 +1,1 @@
+module.exports = require('../src/config/core.js');

--- a/tailwind/index.js
+++ b/tailwind/index.js
@@ -3,6 +3,21 @@ const util = require('./src/util.js');
 
 module.exports = {
   preset,
-  plugins: preset.plugins || [],
+  presetLinq: require('./themes/linq.js'),
+  plugins: {
+    aspectRatio: require('./plugins/aspect-ratio'),
+    base: require('./plugins/base'),
+    button: require('./plugins/button'),
+    container: require('./plugins/container'),
+    focus: require('./plugins/focus'),
+    fontFace: require('./plugins/font-face'),
+    form: require('./plugins/form'),
+    icon: require('./plugins/icon'),
+    identifier: require('./plugins/identifier'),
+    link: require('./plugins/link'),
+    logo: require('./plugins/logo'),
+    richText: require('./plugins/rich-text'),
+    typography: require('./plugins/typography'),
+  },
   util,
 };

--- a/tailwind/package.json
+++ b/tailwind/package.json
@@ -20,5 +20,13 @@
   },
   "dependencies": {
     "@tailwindcss/container-queries": "^0.1.1"
+  },
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy:base": "cp -r ./src/* ./dist",
+    "copy:root": "cp package.json ./dist && cp README.md ./dist",
+    "build": "npm run clean && mkdir dist && npm run copy:root && npm run copy:base",
+    "dev": "tailwindcss -i src/input.css -o dist/output.css --watch",
+    "publish": "npm run build && npm publish"
   }
 }

--- a/tailwind/plugins/aspect-ratio/index.js
+++ b/tailwind/plugins/aspect-ratio/index.js
@@ -1,0 +1,12 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(function({ addUtilities }) {
+  addUtilities({
+    '.aspect-square': {
+      aspectRatio: '1 / 1',
+    },
+    '.aspect-video': {
+      aspectRatio: '16 / 9',
+    },
+  });
+});

--- a/tailwind/plugins/base/index.js
+++ b/tailwind/plugins/base/index.js
@@ -1,0 +1,27 @@
+const plugin = require('tailwindcss/plugin');
+const { remToVw } = require('../../src/util.js');
+
+module.exports = plugin(function({ addBase, theme }) {
+  addBase({
+    ':root': {
+      accentColor: theme('colors.blue.darker'),
+    },
+    html: {
+      fontSize: '100%',
+      height: '100%',
+      scrollBehavior: 'smooth',
+    },
+    body: {
+      color: theme('colors.gray.darker'),
+      fontFamily: '"Work Sans", Arial, sans-serif',
+      fontSize: `clamp(${theme('fontSize.mdMin')}, ${remToVw(theme('fontSize.mdMax'))}, ${theme('fontSize.mdMax')})`,
+      letterSpacing: theme('letterSpacing.md'),
+      lineHeight: theme('lineHeight.md'),
+      minHeight: '100%',
+    },
+    '::selection': {
+      backgroundColor: theme('colors.blue.light'),
+      color: theme('colors.white'),
+    },
+  });
+});

--- a/tailwind/plugins/button/index.js
+++ b/tailwind/plugins/button/index.js
@@ -1,0 +1,23 @@
+const plugin = require('tailwindcss/plugin');
+const { pxToRem } = require('../../src/util.js');
+
+module.exports = plugin(function({ addComponents, theme }) {
+  addComponents({
+    '.btn': {
+      alignItems: 'center',
+      backgroundColor: theme('colors.blue.DEFAULT'),
+      color: theme('colors.white'),
+      padding: `${theme('padding.2')} ${theme('padding.4')}`,
+      borderRadius: theme('borderRadius.md'),
+      fontWeight: theme('fontWeight.semibold'),
+      display: 'inline-flex',
+      gap: pxToRem(4),
+      '&:hover': {
+        backgroundColor: theme('colors.blue.dark'),
+      },
+      '&:active': {
+        backgroundColor: theme('colors.blue.darker'),
+      },
+    },
+  });
+});

--- a/tailwind/plugins/container/index.js
+++ b/tailwind/plugins/container/index.js
@@ -1,0 +1,13 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(function({ addComponents, theme }) {
+  addComponents({
+    '.container': {
+      width: '100%',
+      marginLeft: 'auto',
+      marginRight: 'auto',
+      paddingLeft: theme('spacing.4'),
+      paddingRight: theme('spacing.4'),
+    },
+  });
+});

--- a/tailwind/plugins/focus/index.js
+++ b/tailwind/plugins/focus/index.js
@@ -1,0 +1,10 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(function({ addUtilities, theme }) {
+  addUtilities({
+    '.focus-ring': {
+      outline: `2px solid ${theme('colors.blue.DEFAULT')}`,
+      outlineOffset: '2px',
+    },
+  }, ['focus']);
+});

--- a/tailwind/plugins/font-face/index.js
+++ b/tailwind/plugins/font-face/index.js
@@ -1,0 +1,12 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(function({ addBase }) {
+  addBase({
+    '@font-face': {
+      fontFamily: 'Work Sans',
+      fontStyle: 'normal',
+      fontWeight: '400',
+      src: "url('fonts/WorkSans-Regular.woff2') format('woff2')",
+    },
+  });
+});

--- a/tailwind/plugins/form/index.js
+++ b/tailwind/plugins/form/index.js
@@ -1,0 +1,16 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(function({ addComponents, theme }) {
+  addComponents({
+    '.form-input': {
+      padding: `${theme('spacing.2')} ${theme('spacing.3')}`,
+      borderColor: theme('colors.gray.DEFAULT'),
+      borderWidth: '1px',
+      borderRadius: theme('borderRadius.sm'),
+      '&:focus': {
+        outline: 'none',
+        borderColor: theme('colors.blue.DEFAULT'),
+      },
+    },
+  });
+});

--- a/tailwind/plugins/icon/index.js
+++ b/tailwind/plugins/icon/index.js
@@ -1,0 +1,12 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(function({ addUtilities }) {
+  addUtilities({
+    '.icon': {
+      display: 'inline-block',
+      width: '1em',
+      height: '1em',
+      fill: 'currentColor',
+    },
+  });
+});

--- a/tailwind/plugins/identifier/index.js
+++ b/tailwind/plugins/identifier/index.js
@@ -1,0 +1,11 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(function({ addUtilities, theme }) {
+  addUtilities({
+    '.linq-identifier': {
+      fontSize: theme('fontSize.smMax'),
+      fontWeight: theme('fontWeight.bold'),
+      color: theme('colors.blue.dark'),
+    },
+  });
+});

--- a/tailwind/plugins/link/index.js
+++ b/tailwind/plugins/link/index.js
@@ -1,0 +1,13 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(function({ addUtilities, theme }) {
+  addUtilities({
+    '.link': {
+      color: theme('colors.blue.DEFAULT'),
+      textDecoration: 'underline',
+      '&:hover': {
+        color: theme('colors.blue.dark'),
+      },
+    },
+  });
+});

--- a/tailwind/plugins/logo/index.js
+++ b/tailwind/plugins/logo/index.js
@@ -1,0 +1,11 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(function({ addUtilities }) {
+  addUtilities({
+    '.linq-logo': {
+      display: 'inline-block',
+      height: '40px',
+      width: 'auto',
+    },
+  });
+});

--- a/tailwind/plugins/rich-text/index.js
+++ b/tailwind/plugins/rich-text/index.js
@@ -1,0 +1,8 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(function({ addBase, theme }) {
+  addBase({
+    '.rich-text h1': { fontSize: theme('fontSize.2xlMax'), marginBottom: theme('spacing.4') },
+    '.rich-text p': { marginBottom: theme('spacing.4') },
+  });
+});

--- a/tailwind/plugins/typography/index.js
+++ b/tailwind/plugins/typography/index.js
@@ -1,0 +1,15 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(function({ addComponents, theme }) {
+  addComponents({
+    '.text-display': {
+      fontSize: theme('fontSize.3xlMax'),
+      lineHeight: theme('lineHeight.sm'),
+      fontWeight: theme('fontWeight.bold'),
+    },
+    '.text-body': {
+      fontSize: theme('fontSize.mdMax'),
+      lineHeight: theme('lineHeight.md'),
+    },
+  });
+});

--- a/tailwind/themes/linq.js
+++ b/tailwind/themes/linq.js
@@ -1,0 +1,11 @@
+const core = require('../config/core.js');
+
+module.exports = {
+  presets: [core],
+  theme: {
+    colors: core.theme.colors,
+    fontFamily: core.theme.fontFamily,
+    fontSize: core.theme.fontSize,
+    fontWeight: core.theme.fontWeight,
+  },
+};


### PR DESCRIPTION
## Summary
- add new Tailwind plugins under `tailwind/plugins`
- provide LINQ preset theme and config
- export plugins and preset from `index.js`
- add build/dev/publish scripts
- update README with usage instructions

## Testing
- `node -e "console.log('plugins', Object.keys(require('./tailwind/index.js').plugins).length)"` *(fails: Cannot find module '@tailwindcss/container-queries')*