### PR TITLE
Update test project to use design system

### DIFF
--- a/test-project/web-client/angular.json
+++ b/test-project/web-client/angular.json
@@ -33,7 +33,6 @@
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets"],
             "styles": [
-              "@angular/material/prebuilt-themes/deeppurple-amber.css",
               "src/styles.scss"
             ],
             "scripts": []
@@ -95,7 +94,6 @@
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets"],
             "styles": [
-              "@angular/material/prebuilt-themes/deeppurple-amber.css",
               "src/styles.scss"
             ],
             "scripts": []

--- a/test-project/web-client/package.json
+++ b/test-project/web-client/package.json
@@ -53,6 +53,7 @@
     "postcss": "^8.4.38",
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.3",
-    "typescript": "~5.4.2"
+    "typescript": "~5.4.2",
+    "linq-ds/tailwind": "file:../../tailwind"
   }
 }

--- a/test-project/web-client/src/styles.scss
+++ b/test-project/web-client/src/styles.scss
@@ -1,4 +1,5 @@
 @use "@angular/material" as mat;
+@import "linq-ds/tailwind/scss/material-theme";
 
 @import "tailwindcss/base";
 @import "tailwindcss/components";
@@ -7,8 +8,6 @@
 @import "@angular/cdk/overlay-prebuilt.css";
 
 @include mat.all-component-typographies();
-
-@include mat.core();
 
 body {
   @apply bg-slate-300 #{!important};

--- a/test-project/web-client/tailwind.config.js
+++ b/test-project/web-client/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  presets: [require('linq-ds/tailwind/themes/linq')],
   content: ["./src/**/*.{html,scss,ts}"],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- configure test-project to use the `linq-ds` Tailwind/Angular Material theme
- reference the design system preset in Tailwind config
- import the design system Angular Material theme
- remove Angular Material prebuilt theme

## Testing
- `npm --silent run lint` *(fails: ng not found)*